### PR TITLE
Changes manual build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ $ git clone git@github.com:aisamanra/matterhorn.git
 ~~~
 
 Move into the `matterhorn` directory, create a new sandbox, add
-the `mattermost-api` package as an extra dependency, and build the
-package:
+the `mattermost-api` package as an extra dependency, install the
+dependencies, and build the package:
 
 ~~~
 $ cd matterhorn
 $ cabal sandbox init
-$ cabal add-source ../mattermost-api/mattermost-api.cabal
+$ cabal sandbox add-source ../mattermost-api
+$ cabal install
 $ cabal build
 ~~~
 


### PR DESCRIPTION
While running through the manual build instructions, there were a few changes to the commands that were necessary to successfully build. Here is the summary:

- Specify 'sandbox' when adding the extra dependency,
- Specify the dependency's root directory rather than its .cabal file,
- Install the dependencies or else 'cabal build' will fail and report missing dependencies.